### PR TITLE
Support for query parameters in Xero::request()

### DIFF
--- a/src/Xero.php
+++ b/src/Xero.php
@@ -122,6 +122,7 @@ class Xero {
             'headers' => ['Accept' => $accept]
         ];
 
+        // Workaround for Guzzle BC (https://github.com/picqer/xero-php-client/pull/3)
         if (is_array($data) && isset($data['query'])) {
             $options['query'] = $data['query'];
             unset($data['query']);

--- a/src/Xero.php
+++ b/src/Xero.php
@@ -122,6 +122,14 @@ class Xero {
             'headers' => ['Accept' => $accept]
         ];
 
+        if (is_array($data) && isset($data['query'])) {
+            $options['query'] = $data['query'];
+            unset($data['query']);
+            if (count($data) == 0) {
+                $data = null;
+            }
+        }
+
         if ( ! is_null($data))
         {
             $options['body'] = $data;


### PR DESCRIPTION
If 'data' is an array and it contains 'query' as a key, use that as a set of query string params

Because guzzle will throw an exception if `$data` is an array, it felt relatively safe to try and bundle in query in this way. It's not the best, but it avoids BC breaks. 